### PR TITLE
Add pools info endpoint

### DIFF
--- a/geckoterminal_api/api.py
+++ b/geckoterminal_api/api.py
@@ -398,6 +398,19 @@ class GeckoTerminalAPI:
             endpoint=f"/networks/{network}/tokens/{address}/info",
         )
 
+    def network_pools_info(self, network: str, pool_address: str) -> dict:
+       """Get pool tokens info on a network
+
+       Args:
+       ----
+           network: Network id from `networks()` e.g. eth, solana, arbitrum
+           pool_address: Address of pool
+               e.g. 0x60594a405d53811d3bc4766596efd80fd545a270
+       """
+       return self._get(
+           endpoint=f"/networks/{network}/pools/{pool_address}/info"
+       )
+
     @validate(max_addresses=MAX_ADDRESSES, include_list=TOKEN_INFO_INCLUDES)
     def token_info_recently_updated(self, include: list | None = None) -> dict:
         """Get most recently updated 100 tokens info from all networks

--- a/geckoterminal_api/api.py
+++ b/geckoterminal_api/api.py
@@ -399,17 +399,15 @@ class GeckoTerminalAPI:
         )
 
     def network_pool_info(self, network: str, pool_address: str) -> dict:
-       """Get pool tokens info on a network
+        """Get pool tokens info on a network
 
-       Args:
-       ----
-           network: Network id from `networks()` e.g. eth, solana, arbitrum
-           pool_address: Address of pool
-               e.g. 0x60594a405d53811d3bc4766596efd80fd545a270
-       """
-       return self._get(
-           endpoint=f"/networks/{network}/pools/{pool_address}/info"
-       )
+        Args:
+        ----
+            network: Network id from `networks()` e.g. eth, solana, arbitrum
+            pool_address: Address of pool
+                e.g. 0x60594a405d53811d3bc4766596efd80fd545a270
+        """
+        return self._get(endpoint=f"/networks/{network}/pools/{pool_address}/info")
 
     @validate(max_addresses=MAX_ADDRESSES, include_list=TOKEN_INFO_INCLUDES)
     def token_info_recently_updated(self, include: list | None = None) -> dict:

--- a/geckoterminal_api/api.py
+++ b/geckoterminal_api/api.py
@@ -398,7 +398,7 @@ class GeckoTerminalAPI:
             endpoint=f"/networks/{network}/tokens/{address}/info",
         )
 
-    def network_pools_info(self, network: str, pool_address: str) -> dict:
+    def network_pool_info(self, network: str, pool_address: str) -> dict:
        """Get pool tokens info on a network
 
        Args:

--- a/geckoterminal_api/async_api.py
+++ b/geckoterminal_api/async_api.py
@@ -409,7 +409,7 @@ class AsyncGeckoTerminalAPI:
             endpoint=f"/networks/{network}/tokens/{address}/info",
         )
 
-    async def network_pools_info(self, network: str, pool_address: str) -> dict:
+    async def network_pool_info(self, network: str, pool_address: str) -> dict:
        """Get pool tokens info on a network
 
        Args:

--- a/geckoterminal_api/async_api.py
+++ b/geckoterminal_api/async_api.py
@@ -410,17 +410,17 @@ class AsyncGeckoTerminalAPI:
         )
 
     async def network_pool_info(self, network: str, pool_address: str) -> dict:
-       """Get pool tokens info on a network
+        """Get pool tokens info on a network
 
-       Args:
-       ----
-           network: Network id from `networks()` e.g. eth, solana, arbitrum
-           pool_address: Address of pool 
-                e.g. 0x60594a405d53811d3bc4766596efd80fd545a270
-       """
-       return await self._get(
-           endpoint=f"/networks/{network}/pools/{pool_address}/info"
-       )
+        Args:
+        ----
+            network: Network id from `networks()` e.g. eth, solana, arbitrum
+            pool_address: Address of pool
+                 e.g. 0x60594a405d53811d3bc4766596efd80fd545a270
+        """
+        return await self._get(
+            endpoint=f"/networks/{network}/pools/{pool_address}/info"
+        )
 
     @validate(max_addresses=MAX_ADDRESSES, include_list=TOKEN_INFO_INCLUDES)
     async def token_info_recently_updated(self, include: list | None = None) -> dict:

--- a/geckoterminal_api/async_api.py
+++ b/geckoterminal_api/async_api.py
@@ -409,6 +409,19 @@ class AsyncGeckoTerminalAPI:
             endpoint=f"/networks/{network}/tokens/{address}/info",
         )
 
+    async def network_pools_info(self, network: str, pool_address: str) -> dict:
+       """Get pool tokens info on a network
+
+       Args:
+       ----
+           network: Network id from `networks()` e.g. eth, solana, arbitrum
+           pool_address: Address of pool 
+                e.g. 0x60594a405d53811d3bc4766596efd80fd545a270
+       """
+       return await self._get(
+           endpoint=f"/networks/{network}/pools/{pool_address}/info"
+       )
+
     @validate(max_addresses=MAX_ADDRESSES, include_list=TOKEN_INFO_INCLUDES)
     async def token_info_recently_updated(self, include: list | None = None) -> dict:
         """Get most recently updated 100 tokens info from all networks

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -216,3 +216,15 @@ def test_network_pool_trades(client: GeckoTerminalAPI):
     assert "id" in network_pool_trades["data"][0]
     assert "type" in network_pool_trades["data"][0]
     assert "attributes" in network_pool_trades["data"][0]
+
+def test_network_pool_info(client: GeckoTerminalAPI):
+    network_pool_info = client.network_pool_info(
+        network="eth", pool_address="0x60594a405d53811d3bc4766596efd80fd545a270"
+    )
+    assert isinstance(network_pool_info, dict)
+    assert isinstance(network_pool_info["data"], list)
+    assert "data" in network_pool_info
+    assert "id" in network_pool_info["data"][0]
+    assert "type" in network_pool_info["data"][0]
+    assert "attributes" in network_pool_info["data"][0]
+

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -217,6 +217,7 @@ def test_network_pool_trades(client: GeckoTerminalAPI):
     assert "type" in network_pool_trades["data"][0]
     assert "attributes" in network_pool_trades["data"][0]
 
+
 def test_network_pool_info(client: GeckoTerminalAPI):
     network_pool_info = client.network_pool_info(
         network="eth", pool_address="0x60594a405d53811d3bc4766596efd80fd545a270"
@@ -227,4 +228,3 @@ def test_network_pool_info(client: GeckoTerminalAPI):
     assert "id" in network_pool_info["data"][0]
     assert "type" in network_pool_info["data"][0]
     assert "attributes" in network_pool_info["data"][0]
-

--- a/tests/test_async_api.py
+++ b/tests/test_async_api.py
@@ -258,6 +258,7 @@ async def test_network_pool_trades(async_client: AsyncGeckoTerminalAPI):
     assert "attributes" in network_pool_trades["data"][0]
     await async_client.close()
 
+
 @pytest.mark.asyncio
 async def test_network_pool_info(async_client: AsyncGeckoTerminalAPI):
     network_pool_info = await async_client.network_pool_info(

--- a/tests/test_async_api.py
+++ b/tests/test_async_api.py
@@ -257,3 +257,16 @@ async def test_network_pool_trades(async_client: AsyncGeckoTerminalAPI):
     assert "type" in network_pool_trades["data"][0]
     assert "attributes" in network_pool_trades["data"][0]
     await async_client.close()
+
+@pytest.mark.asyncio
+async def test_network_pool_info(async_client: AsyncGeckoTerminalAPI):
+    network_pool_info = await async_client.network_pool_info(
+        network="eth", pool_address="0x60594a405d53811d3bc4766596efd80fd545a270"
+    )
+    assert isinstance(network_pool_info, dict)
+    assert isinstance(network_pool_info["data"], list)
+    assert "data" in network_pool_info
+    assert "id" in network_pool_info["data"][0]
+    assert "type" in network_pool_info["data"][0]
+    assert "attributes" in network_pool_info["data"][0]
+    await async_client.close()


### PR DESCRIPTION
Add method for `/networks/{network}/pools/{pool_address}/info` endpoint.
- Both sync and async
- Provided test coverage