### PR TITLE
Fix incorrect processing of rate limit error message

### DIFF
--- a/geckoterminal_api/api.py
+++ b/geckoterminal_api/api.py
@@ -80,7 +80,7 @@ class GeckoTerminalAPI:
             case 429:
                 raise GeckoTerminalAPIError(
                     status=response.status_code,
-                    err=f"Rate Limited (limit = {json.loads(response.text)['limit']})",
+                    err="Rate Limited",
                 )
             case _:
                 raise GeckoTerminalAPIError(

--- a/geckoterminal_api/async_api.py
+++ b/geckoterminal_api/async_api.py
@@ -85,10 +85,9 @@ class AsyncGeckoTerminalAPI:
                         err=errors,
                     )
                 case 429:
-                    rate_limit = json.loads(await response.text())["limit"]
                     raise GeckoTerminalAPIError(
                         status=response.status,
-                        err=f"Rate Limited (limit = {rate_limit})",
+                        err="Rate Limited",
                     )
                 case _:
                     raise GeckoTerminalAPIError(


### PR DESCRIPTION
Error json used to have `limit` field, I guess. But now there is no such field, so processing of response code 429 throws KeyError exception.

What's done:
- removed obtaining `limit` parameter from server response with status 429