### PR TITLE
Fix response code processing in async client

### DIFF
--- a/geckoterminal_api/async_api.py
+++ b/geckoterminal_api/async_api.py
@@ -64,7 +64,7 @@ class AsyncGeckoTerminalAPI:
                 an exception with the status code and error message.
         """
         if self._session is None:
-            self._session = aiohttp.ClientSession(raise_for_status=True)
+            self._session = aiohttp.ClientSession()
         get_params = {
             "url": self.base_url + endpoint,
             "params": params,
@@ -72,7 +72,6 @@ class AsyncGeckoTerminalAPI:
             "proxy": self.proxy,
         }
         async with self._session.get(**get_params) as response:
-            response.raise_for_status()
             match response.status:
                 case 200:
                     return await response.json()

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,6 +1,7 @@
 import pytest
 
 from geckoterminal_api.api import GeckoTerminalAPI
+from geckoterminal_api.async_api import AsyncGeckoTerminalAPI
 from geckoterminal_api.exceptions import GeckoTerminalAPIError
 
 
@@ -9,7 +10,19 @@ def client() -> GeckoTerminalAPI:
     return GeckoTerminalAPI()
 
 
+@pytest.fixture(scope="module")
+def async_client() -> AsyncGeckoTerminalAPI:
+    return AsyncGeckoTerminalAPI()
+
+
 def test_api_exception(client) -> None:
     # raises 404
     with pytest.raises(GeckoTerminalAPIError):
         client.network_new_pools(network="arb")
+
+
+@pytest.mark.asyncio
+async def test_async_api_exception(async_client) -> None:
+    # raises 404
+    with pytest.raises(GeckoTerminalAPIError):
+        await async_client.network_new_pools(network="arb")


### PR DESCRIPTION
Remove `raise_for_status` keyword passed when initializing `ClientSession`. Also remove explicit call `response.raise_for_status()` for three reasons:

1.  `response.raise_for_status()` is unnecessary if corresponding parameter is already set in client session
2.  [raise_for_status](https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientResponse.raise_for_status) call throws [aiohttp.ClientResponseError](https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientResponseError) if response code is equal or higher than 400, which means that the user gets exception of unexpected type, e.g. when trying to process rate limiting (code 429). 
3. This behavior differs from that of synchronous client.